### PR TITLE
Fix untouchable variable due to GADTs

### DIFF
--- a/src/Surjective.hs
+++ b/src/Surjective.hs
@@ -195,4 +195,4 @@ surjective qBody = do
       coveredMatch coveredPattern = Match coveredPattern (NormalB rhs) []
       caseExp :: Exp
       caseExp = CaseE scrutinee (map coveredMatch coveredPatterns)
-  TExp <$> [|let _ = $(pure caseExp) in $(pure body'')|]
+  TExp <$> [|let _ = $(pure caseExp) :: () in $(pure body'')|]


### PR DESCRIPTION
This is the easiest way to fix #2 , but it has some shortcomings.

Namely, the coverage check doesn't take into account the type of the GADT.